### PR TITLE
Fixed to work with MW v1.24

### DIFF
--- a/SphinxMWSearch.php
+++ b/SphinxMWSearch.php
@@ -546,7 +546,7 @@ class SphinxMWSearchResult extends SearchResult {
 
 	function __construct( $row, $sphinx_client ) {
 		$this->sphinx_client = $sphinx_client;
-		parent::__construct( $row );
+		$this->initFromTitle( Title::makeTitle( $row->page_namespace, $row->page_title ) );
 	}
 
 	/**


### PR DESCRIPTION
Per https://github.com/wikimedia/mediawiki/commit/9b3f84e763810ab101bfc2bdcee7a319eb73218c#diff-9ddd0ade45c3b97619eefbc8971ee8cd, the SearchResult constructor was removed.
