### PR TITLE
Do not assume pecl installation

### DIFF
--- a/SphinxSearch.php
+++ b/SphinxSearch.php
@@ -12,6 +12,8 @@ EOT;
 if ( !class_exists( 'SphinxClient' ) ) {
 	if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 		require_once __DIR__ . '/vendor/autoload.php';
+	} else {
+		require_once __DIR__ . '/sphinxapi.php';
 	}
 }
 


### PR DESCRIPTION
Since Id3a8234e41c39b7ab6309b2102277e92f00195d8, if sphinxapi.php was copied to
the extension folder, search will fail with 'class SphinxClient not found'
because sphinapi.php is never loaded. This patch falls back to loading
sphinxapi.php the old way if vendor/autoload.php is not present.